### PR TITLE
Replace 404 link with Valid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Smart daily purge bot tailor made for the Vanderbilt Discord server.
 
 Will write more detailed stuff here later.
 
-Thx [Pratish](https://github.com/programming-wizard) <3
+Thx [Pratish](https://github.com/pratishrai) <3


### PR DESCRIPTION
That GitHub account doesn't exist but based on contributors this one does.